### PR TITLE
Clean obsolete comment about jar execution context

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -110,7 +110,7 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
   config :periodic_flush, :validate => :boolean, :default => true
 
 
-  # Detect if we are running from a jarfile, pick the right path.
+  # Register default pattern paths
   @@patterns_path = Set.new
   @@patterns_path += [LogStash::Patterns::Core.path]
 


### PR DESCRIPTION
Fix for elasticsearch/logstash#1229