### PR TITLE
Do not add  @timestamp if it is already in dst. #3562

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -286,15 +286,18 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
   def self.event_hash_merge!(dst, src, dups_key = nil)
     src.each do |key, svalue|
       dst[key] = if dst.has_key?(key)
-        dvalue = dst[key]
+        # Do not add timestamp if it is already in dst
+        if key != "@timestamp"
+          dvalue = dst[key]
 
-        if dvalue.is_a?(Hash) && svalue.is_a?(Hash)
-          event_hash_merge!(dvalue, svalue, dups_key)
-        else
-          v = (dups_key == key) ? Array(dvalue) + Array(svalue) : Array(dvalue) | Array(svalue)
-          # the v result is always an Array, if none of the fields were arrays and there is a
-          # single value in the array, return the value, not the array
-          dvalue.is_a?(Array) || svalue.is_a?(Array) ? v : (v.size == 1 ? v.first : v)
+          if dvalue.is_a?(Hash) && svalue.is_a?(Hash)
+            event_hash_merge!(dvalue, svalue, dups_key)
+          else
+            v = (dups_key == key) ? Array(dvalue) + Array(svalue) : Array(dvalue) | Array(svalue)
+            # the v result is always an Array, if none of the fields were arrays and there is a
+            # single value in the array, return the value, not the array
+            dvalue.is_a?(Array) || svalue.is_a?(Array) ? v : (v.size == 1 ? v.first : v)
+          end
         end
       else
         svalue


### PR DESCRIPTION
PR to correct issue: https://github.com/elastic/logstash/issues/3562

This avoids building up a huge array of timestamps and taking only the first one later on in
function merge().
