### PR TITLE
Fix leftover reference to the type key

### DIFF
--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -17,7 +17,6 @@ require "set"
 # [source,ruby]
 #     filter {
 #       multiline {
-#         type => "type"
 #         pattern => "pattern, a regexp"
 #         negate => boolean
 #         what => "previous" or "next"
@@ -39,7 +38,6 @@ require "set"
 # [source,ruby]
 #     filter {
 #       multiline {
-#         type => "somefiletype"
 #         pattern => "^\s"
 #         what => "previous"
 #       }
@@ -51,7 +49,6 @@ require "set"
 # [source,ruby]
 #     filter {
 #       multiline {
-#         type => "somefiletype "
 #         pattern => "\\$"
 #         what => "next"
 #       }


### PR DESCRIPTION
If one includes the example, as written, from the docs it yields an explosion:

> Error: The setting `type` in plugin `multiline` is obsolete and is no longer available. You can achieve this same behavior with the new conditionals, like: `if [type] == "sometype" { multiline { ... } }`. If you have any questions about this, you are invited to visit https://discuss.elastic.co/c/logstash and ask.
