### PR TITLE
make logstash-filter-mutate a development dependency

### DIFF
--- a/logstash-filter-multiline.gemspec
+++ b/logstash-filter-multiline.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
   s.add_runtime_dependency 'logstash-patterns-core'
-  s.add_runtime_dependency 'logstash-filter-mutate'
+  s.add_development_dependency 'logstash-filter-mutate'
   s.add_runtime_dependency 'jls-grok', '~> 0.11.0'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
This fix issues like the one commented at https://github.com/elastic/logstash/issues/3152#issuecomment-153128843, mutate should not be a runtime as is only used in tests.