### PR TITLE
Fix metadata handling when N>1 sequence of not matched events happen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.0.3
+ - Fix metadata handling, fixes #19 and #22
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -228,8 +228,10 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
       # this line is not part of the previous event if we have a pending event, it's done, send it.
       # put the current event into pending
       unless pending.empty?
-        tmp = event.to_hash_with_metadata
-        event.overwrite(merge(pending))
+        tmp           = event.to_hash_with_metadata
+        merged_events = merge(pending)
+        event.overwrite(merged_events)
+        event["@metadata"] = merged_events["@metadata"] # Override does not copy the metadata
         pending.clear # avoid array creation
         pending << LogStash::Event.new(tmp)
       else
@@ -253,7 +255,9 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
       # if we have something in pending, join it with this message and send it.
       # otherwise, this is a new message and not part of multiline, send it.
       unless pending.empty?
-        event.overwrite(merge(pending << event))
+        merged_events = merge(pending << event)
+        event.overwrite(merged_events)
+        event["@metadata"] = merged_events["@metadata"] # Override does not copy the metadata
         pending.clear
       end
     end # if match

--- a/lib/logstash/filters/multiline.rb
+++ b/lib/logstash/filters/multiline.rb
@@ -228,7 +228,7 @@ class LogStash::Filters::Multiline < LogStash::Filters::Base
       # this line is not part of the previous event if we have a pending event, it's done, send it.
       # put the current event into pending
       unless pending.empty?
-        tmp = event.to_hash
+        tmp = event.to_hash_with_metadata
         event.overwrite(merge(pending))
         pending.clear # avoid array creation
         pending << LogStash::Event.new(tmp)

--- a/logstash-filter-multiline.gemspec
+++ b/logstash-filter-multiline.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-filter-multiline'
-  s.version         = '2.0.2'
+  s.version         = '2.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This filter will collapse multiline messages from a single source into one Logstash event."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/filters/multiline_spec.rb
+++ b/spec/filters/multiline_spec.rb
@@ -245,4 +245,23 @@ describe LogStash::Filters::Multiline do
     end
   end
 
+
+  describe "keeps metadata fields after two consecutive non multline lines" do
+    config <<-CONFIG
+    filter {
+       mutate { add_field => { "[@metadata][index]" => "logstash-2015.11.19" } }
+       multiline {
+          pattern => "^%{NUMBER}"
+          what => "previous"
+      }
+    }
+    CONFIG
+
+    sample ["line1", "line2"] do
+      expect(subject).to be_a(Array)
+      expect(subject[0]["@metadata"]).to include("index"=>"logstash-2015.11.19")
+      expect(subject[1]["@metadata"]).to include("index"=>"logstash-2015.11.19")
+    end
+  end
+
 end

--- a/spec/filters/multiline_spec.rb
+++ b/spec/filters/multiline_spec.rb
@@ -254,6 +254,7 @@ describe LogStash::Filters::Multiline do
           pattern => "^%{NUMBER}"
           what => "previous"
       }
+       mutate { add_field => { "[@metadata][type]" => "foo" } }
     }
     CONFIG
 
@@ -261,6 +262,29 @@ describe LogStash::Filters::Multiline do
       expect(subject).to be_a(Array)
       expect(subject[0]["@metadata"]).to include("index"=>"logstash-2015.11.19")
       expect(subject[1]["@metadata"]).to include("index"=>"logstash-2015.11.19")
+      expect(subject[0]["@metadata"]).to include("type"=>"foo")
+      expect(subject[1]["@metadata"]).to include("type"=>"foo")
+    end
+  end
+
+  describe "keeps metadata fields after two consecutive non multline lines" do
+    config <<-CONFIG
+    filter {
+       mutate { add_field => { "[@metadata][index]" => "logstash-2015.11.19" } }
+       multiline {
+          pattern => "^%{NUMBER}"
+          what => "next"
+      }
+       mutate { add_field => { "[@metadata][type]" => "foo" } }
+    }
+    CONFIG
+
+    sample ["line1", "line2"] do
+      expect(subject).to be_a(Array)
+      expect(subject[0]["@metadata"]).to include("index"=>"logstash-2015.11.19")
+      expect(subject[1]["@metadata"]).to include("index"=>"logstash-2015.11.19")
+      expect(subject[0]["@metadata"]).to include("type"=>"foo")
+      expect(subject[1]["@metadata"]).to include("type"=>"foo")
     end
   end
 


### PR DESCRIPTION
As noted in #22 this will make the metadata to be lost, this is because in the previous_fitler function the metadata is not respected as noted in the changes of this PR. This does not happen in the case of the next filter.

Fixes #22 